### PR TITLE
Replace `manyfmt` dependency with local code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ arrayvec = { version = "0.7.4", default-features = false }
 futures-core = { version = "0.3.31", optional = true, default-features = false }
 futures-util = { version = "0.3.31", optional = true, default-features = false }
 cfg-if = { version = "1.0.0", default-features = false }
-# TODO: Remove the trivial usage of manyfmt
-manyfmt = { version = "0.1.0", default-features = false }
 mutants = { version = "0.0.3", default-features = false }
 
 [dev-dependencies]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,8 +1,5 @@
 use core::fmt;
 
-use manyfmt::formats::Unquote;
-use manyfmt::Refmt as _;
-
 use crate::Listener;
 
 /// A [`Listener`] which transforms or discards messages before passing them on to another
@@ -49,8 +46,11 @@ impl<F, T> Filter<F, T, 1> {
 impl<F, T: fmt::Debug, const BATCH: usize> fmt::Debug for Filter<F, T, BATCH> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Filter")
-            // function's type name may be the function name
-            .field("function", &core::any::type_name::<F>().refmt(&Unquote))
+            // functions usually don’t implement Debug, but the type name may be the function name
+            .field(
+                "function",
+                &crate::util::Unquote::type_name_of(&self.function),
+            )
             .field("target", &self.target)
             .finish()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,8 @@ pub use notifier::{Buffer, Notifier, NotifierForwarder};
 mod store;
 pub use store::{Store, StoreLock, StoreLockListener};
 
+mod util;
+
 // -------------------------------------------------------------------------------------------------
 
 /// Type aliases for use in applications where listeners are expected to implement [`Sync`].

--- a/src/store.rs
+++ b/src/store.rs
@@ -5,9 +5,6 @@
 
 use core::fmt;
 
-use manyfmt::formats::Unquote;
-use manyfmt::Refmt as _;
-
 use crate::maybe_sync::{self, MaRc, MaWeak};
 use crate::Listener;
 
@@ -99,7 +96,7 @@ impl<T: ?Sized> fmt::Debug for StoreLockListener<T> {
         f.debug_struct("StoreLockListener")
             // The type name of T may give a useful clue about who this listener is for,
             // without being too verbose or nondeterministic by printing the whole current state.
-            .field("type", &core::any::type_name::<T>().refmt(&Unquote))
+            .field("type", &crate::util::Unquote::type_name::<T>())
             // not useful to print weak_target unless we were to upgrade and lock it
             .field("alive", &(self.0.strong_count() > 0))
             .finish()

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,20 @@
+use core::fmt;
+
+/// Wraps a string such that it does not get quoted when printed with [`fmt::Debug`].
+pub(crate) struct Unquote<'a>(pub &'a str);
+
+impl Unquote<'static> {
+    pub(crate) fn type_name_of<T: ?Sized>(val: &T) -> Self {
+        Unquote(core::any::type_name_of_val(val))
+    }
+
+    pub(crate) fn type_name<T: ?Sized>() -> Self {
+        Unquote(core::any::type_name::<T>())
+    }
+}
+
+impl fmt::Debug for Unquote<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/tests/api/any_flavor/filter.rs
+++ b/tests/api/any_flavor/filter.rs
@@ -1,7 +1,22 @@
 use super::flavor::Notifier;
-use nosy::{Listen as _, Listener as _, Sink};
+use nosy::{Listen as _, Listener as _, NullListener, Sink};
 
 use crate::tools::CaptureBatch;
+
+#[test]
+fn filter_debug() {
+    fn foo(x: &i32) -> Option<i32> {
+        Some(x + 1)
+    }
+    
+    let listener = NullListener.filter(foo);
+    
+    let fn_name = std::any::type_name_of_val(&foo);
+    assert_eq!(
+        format!("{listener:?}"),
+        format!("Filter {{ function: {fn_name}, target: NullListener }}")
+    );
+}
 
 #[test]
 fn filter_filtering_and_drop() {


### PR DESCRIPTION
`manyfmt` is not a large library but this is even simpler, and I don’t expect to have usage patterns that aren’t exactly this.