### PR TITLE
Add `.map()` and `.flatten()` to `Source`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `Source::map()`
+- `Source::flatten()`
+- `impl Default for Cell`
+- `impl Default for CellWithLocal`
+- `impl Listen for Cell`
+- `impl Listen for CellWithLocal`
+
 ## 0.1.0 (2024-12-19)
 
 Initial public release.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ mod gate;
 pub use gate::{Gate, GateListener};
 
 mod source;
-pub use source::{Constant, Source};
+pub use source::{Constant, Flatten, Map, Source};
 
 mod listener;
 pub use listener::{IntoDynListener, Listen, Listener};

--- a/src/source/flatten.rs
+++ b/src/source/flatten.rs
@@ -1,0 +1,197 @@
+use alloc::sync::Arc;
+use alloc::sync::Weak;
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::Ordering;
+
+use crate::GateListener;
+use crate::NotifierForwarder;
+use crate::{maybe_sync, Gate, IntoDynListener, Listen, Listener, Notifier, Source};
+
+// -------------------------------------------------------------------------------------------------
+
+/// A [`Source`] that takes a [`Source`] whose value is another [`Source`] and produces
+/// the value of the latter source.
+///
+/// Construct this by calling [`Source::flatten()`]; see the further documentation there.
+#[derive(Debug)]
+pub struct Flatten<S: Source<Value: Source>>(Arc<Inner<S>>);
+
+#[derive(Debug)]
+struct Inner<S: Source<Value: Source>> {
+    /// Source from which we get the source from which we get the value.
+    source_of_source: S,
+
+    /// Source we got from `source_of_source`, and its generation number.
+    ///
+    /// This is updated upon the next `get()` or `listen()` invocation after `source_of_source`
+    /// notifies us. It is `None` on first construction. It is never locked except during `get()`,
+    /// but`S::Value` is necessarily cloned while it is held.
+    state: maybe_sync::Mutex<Option<State<S::Value>>>,
+
+    /// Incremented when `source_of_source` tells us the source changed.
+    ///
+    /// Comparing this to `source`’s generation number tells you whether `source` is stale.
+    generation_from_listening: AtomicU32,
+
+    /// Notifier for our own listeners.
+    ///
+    /// Design note: It would be nice if we did not need this, and could simply have our clients’
+    /// listeners listen to the two sources. Unfortunately, that would not allow us to attach our
+    /// clients’ listeners to the inner source when a new inner source appears.
+    /// So, we must instead forward explicitly.
+    ///
+    /// TODO: Make `NotifierForwarder` more generic and avoid needing this nested `Arc`?
+    notifier: Arc<Notifier<(), S::Listener>>,
+}
+
+#[derive(Debug)]
+struct State<S> {
+    generation: u32,
+
+    /// This is the “inner” source — the source that comes from `source_of_source`.
+    source: S,
+
+    #[allow(dead_code, reason = "used for its Drop behavior")]
+    /// This gate is how we cancel listening to an old source.
+    gate: Gate,
+}
+
+// -------------------------------------------------------------------------------------------------
+
+impl<S> Flatten<S>
+where
+    S: Source<Value: Source + Clone>,
+    OuterListener<S>: IntoDynListener<(), S::Listener>,
+    InnerListener<S>: IntoDynListener<(), <S::Value as Listen>::Listener>,
+{
+    /// Constructs a source whose value is `source_of_source.get().get()`.
+    pub fn new(source_of_source: S) -> Self {
+        let new_self = Self(Arc::new(Inner {
+            source_of_source,
+            generation_from_listening: AtomicU32::new(0),
+            state: maybe_sync::Mutex::new(None),
+            notifier: Arc::new(Notifier::new()),
+        }));
+
+        new_self.0.source_of_source.listen(OuterListener {
+            shared: Arc::downgrade(&new_self.0),
+        });
+
+        new_self
+    }
+
+    fn get_source_and_listen_if_new(&self) -> S::Value {
+        // First, determine how new a source we need to have.
+        // (It’s okay if this is incremented after we check it.)
+        let needed_generation = self.0.generation_from_listening.load(Ordering::Relaxed);
+
+        match *self.0.state.lock() {
+            Some(State {
+                generation,
+                ref source,
+                gate: _,
+            }) if generation == needed_generation => return source.clone(),
+            _ => {}
+        }
+
+        // The generation did not match; `source_of_source` has a new source for us.
+        // Therefore, *without the lock held*, prepare an updated `State` with the new source.
+        let source = self.0.source_of_source.get();
+
+        // Start listening to the new source.
+        let (gate, gated_forwarder) = Notifier::forwarder(Arc::downgrade(&self.0.notifier)).gate();
+        source.listen(InnerListener(gated_forwarder));
+        let new_state = State {
+            generation: 0,
+            source,
+            gate,
+        };
+
+        // Now, take the lock and store this new state, if nobody else got to it meanwhile.
+        match *self.0.state.lock() {
+            // Someone else got to it first. Use theirs.
+            Some(State {
+                generation,
+                ref source,
+                gate: _,
+            }) if generation >= needed_generation => source.clone(),
+
+            // Generation is old, so replace it.
+            ref mut state_guard => {
+                let source = new_state.source.clone();
+                *state_guard = Some(new_state);
+                source
+            }
+        }
+    }
+}
+
+impl<S> Listen for Flatten<S>
+where
+    S: Source<Value: Source + Clone>,
+{
+    type Msg = ();
+    type Listener = S::Listener;
+
+    fn listen_raw(&self, listener: Self::Listener) {
+        self.0.notifier.listen_raw(listener)
+    }
+
+    fn listen<L: IntoDynListener<Self::Msg, Self::Listener>>(&self, listener: L)
+    where
+        Self: Sized,
+    {
+        self.0.notifier.listen(listener)
+    }
+}
+
+impl<S> Source for Flatten<S>
+where
+    S: Source<Value: Source + Clone>,
+    OuterListener<S>: IntoDynListener<(), S::Listener>,
+    InnerListener<S>: IntoDynListener<(), <S::Value as Listen>::Listener>,
+{
+    type Value = <S::Value as Source>::Value;
+
+    fn get(&self) -> Self::Value {
+        self.get_source_and_listen_if_new().get()
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+#[derive(Debug)]
+#[allow(unnameable_types)] // TODO: really?
+pub struct OuterListener<S: Source<Value: Source>> {
+    shared: Weak<Inner<S>>,
+}
+
+impl<S: Source<Value: Source>> Listener<()> for OuterListener<S> {
+    fn receive(&self, messages: &[()]) -> bool {
+        let Some(shared) = self.shared.upgrade() else {
+            return false;
+        };
+
+        if !messages.is_empty() {
+            shared
+                .generation_from_listening
+                .fetch_add(1, Ordering::Relaxed);
+
+            shared.notifier.notify(&());
+        }
+
+        true
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(unnameable_types)] // TODO: really?
+pub struct InnerListener<S: Source<Value: Source>>(
+    GateListener<NotifierForwarder<(), S::Listener>>,
+);
+
+impl<S: Source<Value: Source>> Listener<()> for InnerListener<S> {
+    fn receive(&self, messages: &[()]) -> bool {
+        self.0.receive(messages)
+    }
+}

--- a/src/source/map.rs
+++ b/src/source/map.rs
@@ -1,0 +1,54 @@
+use core::fmt;
+
+use crate::{Listen, Source};
+
+/// A [`Source`] whose values are produced by applying a function to another source.
+///
+/// Construct this by calling [`Source::map()`]; see the further documentation there.
+pub struct Map<S, F> {
+    // TODO: We can allow one of these two to be unsized, but not both.
+    // Which one would be better?
+    pub(super) function: F,
+    pub(super) source: S,
+}
+
+impl<S: Source, F> Listen for Map<S, F> {
+    type Msg = ();
+
+    type Listener = S::Listener;
+
+    fn listen_raw(&self, listener: Self::Listener) {
+        self.source.listen_raw(listener)
+    }
+
+    fn listen<L: crate::IntoDynListener<Self::Msg, Self::Listener>>(&self, listener: L)
+    where
+        Self: Sized,
+    {
+        self.source.listen(listener)
+    }
+}
+
+impl<S, F, O> Source for Map<S, F>
+where
+    S: Source,
+    F: Fn(S::Value) -> O,
+{
+    type Value = O;
+
+    fn get(&self) -> Self::Value {
+        (self.function)(self.source.get())
+    }
+}
+
+impl<S: fmt::Debug, F> fmt::Debug for Map<S, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Map")
+            .field(
+                "function",
+                &crate::util::Unquote::type_name_of(&self.function),
+            )
+            .field("source", &self.source)
+            .finish()
+    }
+}

--- a/tests/api/any_flavor/source.rs
+++ b/tests/api/any_flavor/source.rs
@@ -1,21 +1,109 @@
-use pretty_assertions::assert_eq;
+use std::sync::Arc;
+
+use nosy::{Listen as _, Sink, Source as _};
 
 use super::flavor;
-use nosy::{Listen as _, Sink};
 
-#[test]
-fn constant_source_debug() {
-    let source = flavor::constant(123);
-    assert_eq!(format!("{source:?}"), "Constant(123)");
-    assert_eq!(format!("{source:#?}"), "Constant(\n    123,\n)");
+// TODO: put this in the flavor modules?
+type CellSource<T> = Arc<nosy::CellSource<T, flavor::DynListener<()>>>;
+
+mod constant {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn debug() {
+        let source = flavor::constant(123);
+        assert_eq!(format!("{source:?}"), "Constant(123)");
+        assert_eq!(format!("{source:#?}"), "Constant(\n    123,\n)");
+    }
+
+    #[test]
+    fn usage() {
+        let sink: Sink<()> = Sink::new();
+        let source = flavor::constant(123u64);
+        source.listen(sink.listener()); // doesn't panic, doesn't do anything
+        assert_eq!(source.get(), 123);
+        assert_eq!(source.get(), 123);
+        assert!(sink.drain().is_empty());
+    }
 }
 
-#[test]
-fn constant_source_usage() {
-    let sink: Sink<()> = Sink::new();
-    let source = flavor::constant(123u64);
-    source.listen(sink.listener()); // doesn't panic, doesn't do anything
-    assert_eq!(source.get(), 123);
-    assert_eq!(source.get(), 123);
-    assert!(sink.drain().is_empty());
+mod flatten {
+    use super::*;
+
+    #[test]
+    fn usage() {
+        let cell_1 = flavor::Cell::new(10);
+        let cell_2 = flavor::Cell::new(20);
+        let cell_of_source = flavor::Cell::new(cell_1.as_source());
+
+        let flatten: nosy::Flatten<CellSource<CellSource<i8>>> =
+            cell_of_source.as_source().flatten();
+        let sink: Sink<()> = Sink::new();
+        flatten.listen(sink.listener());
+
+        // Initial outcomes: correct value, and no notifications.
+        assert_eq!(flatten.get(), 10, "initial get");
+        assert_eq!(sink.drain().len(), 0, "initial notif");
+
+        // Change the first source.
+        cell_1.set(11);
+        assert_eq!(sink.drain().len(), 1, "cell_1 notif");
+        assert_eq!(flatten.get(), 11, "cell_1 new value");
+        assert_eq!(sink.drain().len(), 0, "cell_1 no notif");
+
+        // Change sources.
+        cell_of_source.set(cell_2.as_source());
+        assert_eq!(sink.drain().len(), 1, "source notif");
+        assert_eq!(flatten.get(), 20, "source new value");
+        assert_eq!(sink.drain().len(), 0, "source no notif");
+
+        // Change the second source.
+        cell_2.set(21);
+        assert_eq!(sink.drain().len(), 1, "cell_2 notif");
+        assert_eq!(flatten.get(), 21, "cell_2 new value");
+        assert_eq!(sink.drain().len(), 0, "cell_2 no notif");
+
+        // Change the first source and expect no notification.
+        cell_1.set(11);
+        assert_eq!(sink.drain().len(), 0, "cell_1 obsolete no notif");
+        assert_eq!(flatten.get(), 21, "cell_1 obsolete no value change");
+    }
+
+    // TODO: test weak-ref/leak-related behaviors
+}
+
+mod map {
+    use super::*;
+
+    #[test]
+    fn debug() {
+        fn some_map_fn(_: i32) -> i32 {
+            456
+        }
+        let mapped = flavor::constant(123).map(some_map_fn);
+
+        let fn_name = std::any::type_name_of_val(&some_map_fn);
+        assert_eq!(
+            format!("{mapped:?}"),
+            format!("Map {{ function: {fn_name}, source: Constant(123) }}")
+        );
+    }
+
+    #[test]
+    fn usage() {
+        let cell = flavor::Cell::new(1);
+        let mapped: nosy::Map<CellSource<u8>, _> = cell.as_source().map(|x: u8| u16::from(x) * 100);
+        let sink: Sink<()> = Sink::new();
+        mapped.listen(sink.listener());
+
+        assert_eq!(mapped.get(), 100u16);
+        assert_eq!(sink.drain().len(), 0);
+
+        cell.set(2);
+        assert_eq!(sink.drain().len(), 1);
+        assert_eq!(mapped.get(), 200u16);
+        assert_eq!(sink.drain().len(), 0);
+    }
 }


### PR DESCRIPTION
`map()` is a basic tool for cheap adaptations. It is not suitable for arbitrary derived sources since it does no comparison, so spurious notifications may pass through, and no memoization, so the mapped output will be constructed anew for every `get()`. Still, it is useful for adapting types, and for field projections where all fields are expected to change together.

`flatten()` is less basic, but also something that is rather tricky to write, so I hope that this implementation will be often useful. I was hoping I could manage to do it without using any mutex, but I did not succeed; notably, the previously-recorded inner source has to be cloned, and we can’t express that without mutual exclusion. There could perhaps be an implementation which doesn’t store the inner source at all, but it would require adding lots of one-shot listeners, which has its own costs and is contrary to the design of the library.