### PR TITLE
Rename `Sink` to `Log`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - `impl Listen for Cell`
 - `impl Listen for CellWithLocal`
 
+### Changed
+
+- Renamed `Sink` to `Log`, to clarify that it is not the opposite of `Source`.
+
 ## 0.1.0 (2024-12-19)
 
 Initial public release.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2020-2024 Kevin Reid
+Copyright 2020-2025 Kevin Reid
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ mod listener;
 pub use listener::{IntoDynListener, Listen, Listener};
 
 mod simple_listeners;
-pub use simple_listeners::{Flag, FlagListener, NullListener, Sink, SinkListener};
+pub use simple_listeners::{Flag, FlagListener, Log, LogListener, NullListener};
 
 mod maybe_sync;
 

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -160,16 +160,16 @@ pub trait Listener<M>: fmt::Debug {
     /// This may be used to stop forwarding messages when a dependency no longer exists.
     ///
     /// ```
-    /// use nosy::{Gate, Listen as _, Listener as _, Sink};
+    /// use nosy::{Listen as _, Listener as _};
     ///
-    /// let sink = Sink::new();
-    /// let (gate, gated) = sink.listener().gate();
+    /// let log = nosy::Log::new();
+    /// let (gate, gated) = log.listener().gate();
     /// gated.receive(&["kept1"]);
-    /// assert_eq!(sink.drain(), vec!["kept1"]);
+    /// assert_eq!(log.drain(), vec!["kept1"]);
     /// gated.receive(&["kept2"]);
     /// drop(gate);
     /// gated.receive(&["discarded"]);
-    /// assert_eq!(sink.drain(), vec!["kept2"]);
+    /// assert_eq!(log.drain(), vec!["kept2"]);
     /// ```
     fn gate(self) -> (Gate, crate::GateListener<Self>)
     where

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -86,25 +86,25 @@ impl<M, L: Listener<M>> Notifier<M, L> {
     ///
     /// ```
     /// use std::sync::Arc;
-    #[cfg_attr(feature = "sync", doc = " use nosy::{Listen, sync::Notifier, Sink};")]
+    #[cfg_attr(feature = "sync", doc = " use nosy::{Listen, sync::Notifier, Log};")]
     #[cfg_attr(
         not(feature = "sync"),
-        doc = " use nosy::{Listen, unsync::Notifier, Sink};"
+        doc = " use nosy::{Listen, unsync::Notifier, Log};"
     )]
     ///
     /// let notifier_1 = Notifier::new();
     /// let notifier_2 = Arc::new(Notifier::new());
-    /// let mut sink = Sink::new();
+    /// let mut log = Log::new();
     /// notifier_1.listen(Notifier::forwarder(Arc::downgrade(&notifier_2)));
-    /// notifier_2.listen(sink.listener());
+    /// notifier_2.listen(log.listener());
     /// # assert_eq!(notifier_1.count(), 1);
     /// # assert_eq!(notifier_2.count(), 1);
     ///
     /// notifier_1.notify(&"a");
-    /// assert_eq!(sink.drain(), vec!["a"]);
+    /// assert_eq!(log.drain(), vec!["a"]);
     /// drop(notifier_2);
     /// notifier_1.notify(&"a");
-    /// assert!(sink.drain().is_empty());
+    /// assert!(log.drain().is_empty());
     ///
     /// # assert_eq!(notifier_1.count(), 0);
     /// ```
@@ -154,24 +154,24 @@ impl<M, L: Listener<M>> Notifier<M, L> {
     /// # Example
     ///
     /// ```
-    /// use nosy::{Listen as _, unsync::Notifier, Sink};
+    /// use nosy::{Listen as _, unsync::Notifier, Log};
     ///
     /// let notifier: Notifier<&str> = Notifier::new();
-    /// let sink: Sink<&str> = Sink::new();
-    /// notifier.listen(sink.listener());
+    /// let log: Log<&str> = Log::new();
+    /// notifier.listen(log.listener());
     ///
     /// let mut buffer = notifier.buffer::<2>();
     ///
     /// // The buffer fills up and sends after two messages.
     /// buffer.push("hello");
-    /// assert!(sink.drain().is_empty());
+    /// assert!(log.drain().is_empty());
     /// buffer.push("and");
-    /// assert_eq!(sink.drain(), vec!["hello", "and"]);
+    /// assert_eq!(log.drain(), vec!["hello", "and"]);
     ///
     /// // The buffer also sends when it is dropped.
     /// buffer.push("goodbye");
     /// drop(buffer);
-    /// assert_eq!(sink.drain(), vec!["goodbye"]);
+    /// assert_eq!(log.drain(), vec!["goodbye"]);
     /// ```
     pub fn buffer<const CAPACITY: usize>(&self) -> Buffer<'_, M, L, CAPACITY> {
         Buffer::new(self)

--- a/src/simple_listeners.rs
+++ b/src/simple_listeners.rs
@@ -48,39 +48,39 @@ where
 ///
 /// * `M` is the type of the messages.
 #[derive(Debug)]
-pub struct Sink<M>(StoreLock<Vec<M>>);
+pub struct Log<M>(StoreLock<Vec<M>>);
 
-/// [`Sink::listener()`] implementation.
+/// [`Log::listener()`] implementation.
 ///
 /// # Generic parameters
 ///
 /// * `M` is the type of the messages.
-pub struct SinkListener<M>(StoreLockListener<Vec<M>>);
+pub struct LogListener<M>(StoreLockListener<Vec<M>>);
 
-impl<M> Sink<M> {
-    /// Constructs a new empty [`Sink`].
+impl<M> Log<M> {
+    /// Constructs a new empty [`Log`].
     #[must_use]
     pub fn new() -> Self {
         Self(StoreLock::default())
     }
 
-    /// Returns a [`Listener`] which records the messages it receives in this Sink.
+    /// Returns a [`Listener`] which records the messages it receives in this `Log`.
     #[must_use]
-    pub fn listener(&self) -> SinkListener<M> {
-        SinkListener(self.0.listener())
+    pub fn listener(&self) -> LogListener<M> {
+        LogListener(self.0.listener())
     }
 
     /// Remove and return all messages returned so far.
     ///
     /// ```
-    /// use nosy::{Listener, Sink};
+    /// use nosy::{Listener, Log};
     ///
-    /// let sink = Sink::new();
-    /// sink.listener().receive(&[1]);
-    /// sink.listener().receive(&[2]);
-    /// assert_eq!(sink.drain(), vec![1, 2]);
-    /// sink.listener().receive(&[3]);
-    /// assert_eq!(sink.drain(), vec![3]);
+    /// let log = Log::new();
+    /// log.listener().receive(&[1]);
+    /// log.listener().receive(&[2]);
+    /// assert_eq!(log.drain(), vec![1, 2]);
+    /// log.listener().receive(&[3]);
+    /// assert_eq!(log.drain(), vec![3]);
     /// ```
     #[must_use]
     pub fn drain(&self) -> Vec<M> {
@@ -88,25 +88,25 @@ impl<M> Sink<M> {
     }
 }
 
-impl<M> fmt::Debug for SinkListener<M> {
+impl<M> fmt::Debug for LogListener<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("SinkListener").field(&self.0).finish()
+        f.debug_tuple("LogListener").field(&self.0).finish()
     }
 }
 
-impl<M: Clone + Send + Sync> Listener<M> for SinkListener<M> {
+impl<M: Clone + Send + Sync> Listener<M> for LogListener<M> {
     fn receive(&self, messages: &[M]) -> bool {
         self.0.receive(messages)
     }
 }
 
-impl<M> Clone for SinkListener<M> {
+impl<M> Clone for LogListener<M> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<M> Default for Sink<M> {
+impl<M> Default for Log<M> {
     // This implementation cannot be derived because we do not want M: Default
     fn default() -> Self {
         Self::new()

--- a/tests/api/any_flavor/cell.rs
+++ b/tests/api/any_flavor/cell.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use pretty_assertions::assert_eq;
 
-use nosy::{Listen as _, Sink, Source as _};
 use super::flavor;
+use nosy::{Listen as _, Log, Source as _};
 
 #[test]
 fn cell_and_source_debug() {
@@ -41,13 +41,13 @@ fn cell_usage() {
     let cell = flavor::Cell::<i32>::new(0i32);
 
     let s = cell.as_source();
-    let sink = Sink::new();
-    s.listen(sink.listener());
+    let log = Log::new();
+    s.listen(log.listener());
 
-    assert_eq!(sink.drain(), vec![]);
+    assert_eq!(log.drain(), vec![]);
     cell.set(1);
     assert_eq!(1, s.get());
-    assert_eq!(sink.drain(), vec![()]);
+    assert_eq!(log.drain(), vec![()]);
 }
 
 #[test]

--- a/tests/api/any_flavor/filter.rs
+++ b/tests/api/any_flavor/filter.rs
@@ -1,5 +1,5 @@
 use super::flavor::Notifier;
-use nosy::{Listen as _, Listener as _, NullListener, Sink};
+use nosy::{Listen as _, Listener as _, NullListener, Log};
 
 use crate::tools::CaptureBatch;
 
@@ -21,17 +21,17 @@ fn filter_debug() {
 #[test]
 fn filter_filtering_and_drop() {
     let notifier: Notifier<Option<i32>> = Notifier::new();
-    let sink = Sink::new();
-    notifier.listen(sink.listener().filter(|&x| x));
+    let log = Log::new();
+    notifier.listen(log.listener().filter(|&x| x));
     assert_eq!(notifier.count(), 1);
 
     // Try delivering messages
     notifier.notify(&Some(1));
     notifier.notify(&None);
-    assert_eq!(sink.drain(), vec![1]);
+    assert_eq!(log.drain(), vec![1]);
 
-    // Drop the sink and the notifier should observe it gone
-    drop(sink);
+    // Drop the log and the notifier should observe it gone
+    drop(log);
     assert_eq!(notifier.count(), 0);
 }
 
@@ -40,8 +40,8 @@ fn filter_filtering_and_drop() {
 #[test]
 fn filter_batch_size_1() {
     let notifier: Notifier<i32> = Notifier::new();
-    let sink: Sink<Vec<i32>> = Sink::new();
-    notifier.listen(CaptureBatch(sink.listener()).filter(|&x: &i32| Some(x)));
+    let log: Log<Vec<i32>> = Log::new();
+    notifier.listen(CaptureBatch(log.listener()).filter(|&x: &i32| Some(x)));
 
     // Send some batches
     notifier.notify_many(&[0, 1]);
@@ -50,7 +50,7 @@ fn filter_batch_size_1() {
 
     // Expect the batches to be of size at most 1
     assert_eq!(
-        sink.drain(),
+        log.drain(),
         vec![vec![], vec![0], vec![1], vec![], vec![2], vec![3]]
     );
 }
@@ -58,9 +58,9 @@ fn filter_batch_size_1() {
 #[test]
 fn filter_batching_nzst() {
     let notifier: Notifier<i32> = Notifier::new();
-    let sink: Sink<Vec<i32>> = Sink::new();
+    let log: Log<Vec<i32>> = Log::new();
     notifier.listen(
-        CaptureBatch(sink.listener())
+        CaptureBatch(log.listener())
             .filter(|&x: &i32| Some(x))
             .with_stack_buffer::<2>(),
     );
@@ -72,7 +72,7 @@ fn filter_batching_nzst() {
 
     // Expect the batches to be of size at most 2
     assert_eq!(
-        sink.drain(),
+        log.drain(),
         vec![vec![], vec![0, 1], vec![], vec![2, 3], vec![4]]
     );
 }
@@ -81,9 +81,9 @@ fn filter_batching_nzst() {
 #[test]
 fn filter_batching_zst() {
     let notifier: Notifier<i32> = Notifier::new();
-    let sink: Sink<Vec<()>> = Sink::new();
+    let log: Log<Vec<()>> = Log::new();
     notifier.listen(
-        CaptureBatch(sink.listener()).filter(|&x: &i32| if x == 2 { None } else { Some(()) }),
+        CaptureBatch(log.listener()).filter(|&x: &i32| if x == 2 { None } else { Some(()) }),
     );
 
     // Send some batches
@@ -93,7 +93,7 @@ fn filter_batching_zst() {
 
     // Expect batches to be preserved and filtered, even though we didn’t set a batch size.
     assert_eq!(
-        sink.drain(),
+        log.drain(),
         vec![
             vec![],           // initial liveness check on listen()
             vec![(), ()],     // first nonempty batch

--- a/tests/api/any_flavor/gate.rs
+++ b/tests/api/any_flavor/gate.rs
@@ -1,24 +1,24 @@
 use super::flavor::Notifier;
-use nosy::{Listen as _, Listener as _, Sink};
+use nosy::{Listen as _, Listener as _, Log};
 
 #[test]
 fn gate() {
     let notifier: Notifier<i32> = Notifier::new();
-    let sink = Sink::new();
-    let (gate, listener): (nosy::Gate, nosy::GateListener<nosy::SinkListener<i32>>) =
-        sink.listener().gate();
+    let log = Log::new();
+    let (gate, listener): (nosy::Gate, nosy::GateListener<nosy::LogListener<i32>>) =
+        log.listener().gate();
     notifier.listen(listener);
     assert_eq!(notifier.count(), 1);
 
     // Try delivering messages
     notifier.notify(&1);
-    assert_eq!(sink.drain(), vec![1]);
+    assert_eq!(log.drain(), vec![1]);
 
     // Drop the gate and messages should stop passing immediately
     // (even though we didn't even trigger notifier cleanup by calling count())
     drop(gate);
     notifier.notify(&2);
-    assert_eq!(sink.drain(), Vec::<i32>::new());
+    assert_eq!(log.drain(), Vec::<i32>::new());
 
     assert_eq!(notifier.count(), 0);
 }

--- a/tests/api/any_flavor/notifier.rs
+++ b/tests/api/any_flavor/notifier.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use nosy::{Listen as _, Listener, Sink};
 use super::flavor::Notifier;
+use nosy::{Listen as _, Listener, Log};
 
 #[test]
 fn basics_and_debug() {
@@ -9,15 +9,15 @@ fn basics_and_debug() {
     assert_eq!(format!("{cn:?}"), "Notifier(0)");
     cn.notify(&0);
     assert_eq!(format!("{cn:?}"), "Notifier(0)");
-    let sink = Sink::new();
-    cn.listen(sink.listener());
+    let log = Log::new();
+    cn.listen(log.listener());
     assert_eq!(format!("{cn:?}"), "Notifier(1)");
     // type annotation to prevent spurious inference failures in the presence
     // of other compiler errors
-    assert_eq!(sink.drain(), Vec::<u8>::new());
+    assert_eq!(log.drain(), Vec::<u8>::new());
     cn.notify(&1);
     cn.notify(&2);
-    assert_eq!(sink.drain(), vec![1, 2]);
+    assert_eq!(log.drain(), vec![1, 2]);
     assert_eq!(format!("{cn:?}"), "Notifier(1)");
 }
 

--- a/tests/api/any_flavor/simple_listeners.rs
+++ b/tests/api/any_flavor/simple_listeners.rs
@@ -1,5 +1,5 @@
 use super::flavor::Notifier;
-use nosy::{Flag, Listen as _, Listener as _, NullListener, Sink};
+use nosy::{Flag, Listen as _, Listener as _, Log, NullListener};
 
 #[test]
 fn null_alive() {
@@ -10,31 +10,31 @@ fn null_alive() {
 
 #[test]
 fn tuple() {
-    let sink = Sink::new();
+    let log = Log::new();
 
     // Tuple of alive listener and dead listener is alive
-    assert_eq!((sink.listener(), NullListener).receive(&["SN"]), true);
-    assert_eq!(sink.drain(), vec!["SN"]);
+    assert_eq!((log.listener(), NullListener).receive(&["SN"]), true);
+    assert_eq!(log.drain(), vec!["SN"]);
 
     // Tuple of dead listener and alive listener is alive
-    assert_eq!((NullListener, sink.listener()).receive(&["NS"]), true);
-    assert_eq!(sink.drain(), vec!["NS"]);
+    assert_eq!((NullListener, log.listener()).receive(&["NS"]), true);
+    assert_eq!(log.drain(), vec!["NS"]);
 
     // Tuple of alive listener and alive listener is alive
-    assert_eq!((sink.listener(), sink.listener()).receive(&["SS"]), true);
-    assert_eq!(sink.drain(), vec!["SS", "SS"]);
+    assert_eq!((log.listener(), log.listener()).receive(&["SS"]), true);
+    assert_eq!(log.drain(), vec!["SS", "SS"]);
 
     // Tuple of dead listener and dead listener is dead
     assert_eq!((NullListener, NullListener).receive(&["NN"]), false);
 }
 
 #[test]
-fn sink_alive() {
+fn log_alive() {
     let notifier: Notifier<()> = Notifier::new();
-    let sink = Sink::new();
-    notifier.listen(sink.listener());
+    let log = Log::new();
+    notifier.listen(log.listener());
     assert_eq!(notifier.count(), 1);
-    drop(sink);
+    drop(log);
     assert_eq!(notifier.count(), 0);
 }
 

--- a/tests/api/listener.rs
+++ b/tests/api/listener.rs
@@ -4,7 +4,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use nosy::{sync, unsync, Flag, IntoDynListener as _, Listen, NullListener, Sink};
+use nosy::{sync, unsync, Flag, IntoDynListener as _, Listen, Log, NullListener};
 
 #[test]
 fn dyn_listen_is_possible() {
@@ -20,8 +20,8 @@ fn dyn_listen_is_possible() {
 
 #[test]
 fn dyn_listener_unsync() {
-    let sink = Sink::new();
-    let listener: unsync::DynListener<&str> = sink.listener().into_dyn_listener();
+    let log = Log::new();
+    let listener: unsync::DynListener<&str> = log.listener().into_dyn_listener();
 
     // Should not gain a new wrapper when erased() again.
     assert_eq!(
@@ -34,17 +34,17 @@ fn dyn_listener_unsync() {
 
     // Should deliver messages.
     assert!(listener.receive(&["a"]));
-    assert_eq!(sink.drain(), vec!["a"]);
+    assert_eq!(log.drain(), vec!["a"]);
 
     // Should report dead
-    drop(sink);
+    drop(log);
     assert!(!listener.receive(&[]));
     assert!(!listener.receive(&["b"]));
 }
 
 #[test]
 fn dyn_listener_sync() {
-    // Flag, unlike Sink, is always Send + Sync so is ok to use in this test
+    // Flag, unlike Log, is always Send + Sync so is ok to use in this test
     // without making it conditional.
     let flag = Flag::new(false);
     let listener: sync::DynListener<&str> = flag.listener().into_dyn_listener();

--- a/tests/api/static_properties.rs
+++ b/tests/api/static_properties.rs
@@ -109,13 +109,13 @@ const _: () = {
 
     assert_impl_all!(nosy::NullListener: Copy, Send, Sync, RefUnwindSafe, UnwindSafe);
 
-    assert_send_sync_if_cfg::<nosy::Sink<()>>();
-    assert_not_impl_any!(nosy::Sink<*const ()>: Send, Sync);
-    assert_not_impl_any!(nosy::Sink<()>: RefUnwindSafe, UnwindSafe);
+    assert_send_sync_if_cfg::<nosy::Log<()>>();
+    assert_not_impl_any!(nosy::Log<*const ()>: Send, Sync);
+    assert_not_impl_any!(nosy::Log<()>: RefUnwindSafe, UnwindSafe);
 
-    assert_impl_all!(nosy::SinkListener<()>: Clone);
-    assert_send_sync_if_cfg::<nosy::SinkListener<()>>();
-    assert_not_impl_any!(nosy::SinkListener<()>: RefUnwindSafe, UnwindSafe);
+    assert_impl_all!(nosy::LogListener<()>: Clone);
+    assert_send_sync_if_cfg::<nosy::LogListener<()>>();
+    assert_not_impl_any!(nosy::LogListener<()>: RefUnwindSafe, UnwindSafe);
 
     assert_impl_all!(nosy::StoreLock<Vec<()>>: Unpin);
     assert_not_impl_any!(nosy::StoreLock<Vec<()>>: RefUnwindSafe, UnwindSafe);


### PR DESCRIPTION
I believe `Sink` is confusing because it sounds like it is the opposite of `Source`, and I might or might not want to create something that *actually* is that opposite (for derived-value cells).