### PR TITLE
Add `Store::take()` and expand documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@
 #![warn(clippy::unnecessary_self_imports)]
 #![warn(clippy::unnecessary_wraps)]
 #![allow(clippy::bool_assert_comparison, reason = "less legible")]
+#![allow(clippy::explicit_auto_deref)]
 #![allow(clippy::explicit_iter_loop)]
 #![allow(clippy::semicolon_if_nothing_returned, reason = "explicit delegation")]
 #![cfg_attr(test, allow(clippy::arc_with_non_send_sync))]


### PR DESCRIPTION
`Store::take()` keeps the example tidy, but more importantly, it correctly implements taking the lock for the minimum amount of time, which is not at all obvious if you’re not accustomed to thinking about evaluation order. (We could also offer `Store::swap()` for when `T` needs to allocate, but that makes more sense as a separate struct that owns the swapped `T` too; I have a WIP version of that but I’m waiting to see real use cases where it is actually the right tool.)

Removed “except for such locks”, which was copied from the `Listener` documentation and does not make sense here.