### PR TITLE
Change deprecated alias from `use` to `type`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,9 +189,11 @@ pub use store::{Store, StoreLock, StoreLockListener};
 mod util;
 
 #[deprecated = "use `Log` instead of `Sink`"]
-pub use Log as Sink;
+#[allow(missing_docs)]
+pub type Sink<M> = Log<M>;
 #[deprecated = "use `LogListener` instead of `SinkListener`"]
-pub use LogListener as SinkListener;
+#[allow(missing_docs)]
+pub type SinkListener<M> = LogListener<M>;
 
 // -------------------------------------------------------------------------------------------------
 

--- a/tests/api/static_properties.rs
+++ b/tests/api/static_properties.rs
@@ -151,3 +151,9 @@ const _: () = {
         assert_impl_all!(nosy::future::WakeFlagListener: Clone, Send, Sync, Unpin, RefUnwindSafe, UnwindSafe);
     }
 };
+
+// Test that deprecations are as expected
+#[expect(unused, deprecated)]
+use nosy::Sink as SinkIsDeprecated;
+#[expect(unused, deprecated)]
+use nosy::SinkListener as SinkListenerIsDeprecated;


### PR DESCRIPTION
`#[deprecated` doesn't work on re-exports (https://github.com/rust-lang/rust/issues/30827).