### PR TITLE
Fix lint.

### DIFF
--- a/tests/api/static_properties.rs
+++ b/tests/api/static_properties.rs
@@ -47,12 +47,12 @@ const _: () = {
 
     // CellSource, sync and unsync flavors.
     type CellSourceU<T> = nosy::CellSource<T, nosy::unsync::DynListener<()>>;
-    type CellSourceS<T> = nosy::CellSource<T, nosy::sync::DynListener<()>>;
     assert_impl_all!(CellSourceU<()>: Unpin);
     assert_not_impl_any!(CellSourceU<()>: Send, Sync, RefUnwindSafe, UnwindSafe);
     assert_not_impl_any!(CellSourceU<*const ()>: Send, Sync);
     #[cfg(feature = "sync")]
     {
+        type CellSourceS<T> = nosy::CellSource<T, nosy::sync::DynListener<()>>;
         assert_impl_all!(CellSourceS<()>: Send, Sync, Unpin);
         assert_not_impl_any!(CellSourceS<*const ()>: Send, Sync);
         assert_not_impl_any!(CellSourceS<()>: RefUnwindSafe, UnwindSafe);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn cargo(sh: &Shell) -> Cmd {
+fn cargo(sh: &Shell) -> Cmd<'_> {
     sh.cmd(std::env::var("CARGO").expect("CARGO environment variable not set"))
 }


### PR DESCRIPTION
Old `dead_code`; new `mismatched_lifetime_syntaxes`.