### PR TITLE
Swap around `IntoDynListener<M, L>` trait to be `FromListener<L, M>`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "nosy"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.83.0"
 description = "Change notification / observation / broadcast channels, with filtering and coalescing. no_std compatible."

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{fmt, mem};
 
 use crate::maybe_sync::{Mutex, MutexGuard};
-use crate::{Listen, Listener, Notifier, Source};
+use crate::{IntoListener, Listen, Listener, Notifier, Source};
 
 #[cfg(doc)]
 use crate::{sync, unsync};
@@ -169,8 +169,8 @@ impl<T, L: Listener<()>> Listen for CellSource<T, L> {
         self.notifier.listen_raw(listener);
     }
 
-    fn listen<L2: crate::IntoDynListener<Self::Msg, Self::Listener>>(&self, listener: L2) {
-        self.notifier.listen(listener);
+    fn listen<L2: IntoListener<Self::Listener, Self::Msg>>(&self, listener: L2) {
+        self.notifier.listen(listener)
     }
 }
 impl<T, L: Listener<()>> Listen for Cell<T, L> {
@@ -181,8 +181,8 @@ impl<T, L: Listener<()>> Listen for Cell<T, L> {
         self.shared.listen_raw(listener);
     }
 
-    fn listen<L2: crate::IntoDynListener<Self::Msg, Self::Listener>>(&self, listener: L2) {
-        self.shared.listen(listener);
+    fn listen<L2: IntoListener<Self::Listener, Self::Msg>>(&self, listener: L2) {
+        self.shared.listen(listener)
     }
 }
 impl<T, L: Listener<()>> Listen for CellWithLocal<T, L> {
@@ -193,8 +193,8 @@ impl<T, L: Listener<()>> Listen for CellWithLocal<T, L> {
         self.cell.listen_raw(listener);
     }
 
-    fn listen<L2: crate::IntoDynListener<Self::Msg, Self::Listener>>(&self, listener: L2) {
-        self.cell.listen(listener);
+    fn listen<L2: IntoListener<Self::Listener, Self::Msg>>(&self, listener: L2) {
+        self.cell.listen(listener)
     }
 }
 

--- a/src/future.rs
+++ b/src/future.rs
@@ -160,7 +160,7 @@ impl WakeFlag {
     pub fn listening<L>(wake_immediately: bool, source: L) -> Self
     where
         L: Listen,
-        WakeFlagListener: crate::IntoDynListener<L::Msg, L::Listener>,
+        L::Listener: crate::FromListener<WakeFlagListener, L::Msg>,
     {
         let (flag, listener) = Self::new(wake_immediately);
         source.listen(listener);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ mod source;
 pub use source::{Constant, Flatten, Map, Source};
 
 mod listener;
-pub use listener::{IntoDynListener, Listen, Listener};
+pub use listener::{FromListener, IntoListener, Listen, Listener};
 
 mod simple_listeners;
 pub use simple_listeners::{Flag, FlagListener, Log, LogListener, NullListener};

--- a/src/simple_listeners.rs
+++ b/src/simple_listeners.rs
@@ -209,7 +209,7 @@ impl Flag {
     pub fn listening<L>(value: bool, source: L) -> Self
     where
         L: Listen,
-        FlagListener: crate::IntoDynListener<L::Msg, L::Listener>,
+        L::Listener: crate::FromListener<FlagListener, L::Msg>,
     {
         let new_self = Self::new(value);
         source.listen(new_self.listener());

--- a/src/source.rs
+++ b/src/source.rs
@@ -7,7 +7,7 @@ use alloc::sync::Arc;
 
 #[cfg(doc)]
 use crate::Notifier;
-use crate::{IntoDynListener, Listen, Listener};
+use crate::{FromListener, IntoListener, Listen, Listener};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -120,8 +120,8 @@ pub trait Source: Listen<Msg = ()> + fmt::Debug {
     where
         Self: Sized,
         Self::Value: Source + Clone,
-        flatten::OuterListener<Self>: IntoDynListener<(), Self::Listener>,
-        flatten::InnerListener<Self>: IntoDynListener<(), <Self::Value as Listen>::Listener>,
+        Self::Listener: FromListener<flatten::OuterListener<Self>, ()>,
+        <Self::Value as Listen>::Listener: FromListener<flatten::InnerListener<Self>, ()>,
     {
         Flatten::new(self)
     }
@@ -191,7 +191,7 @@ impl<T, L: Listener<()>> Listen for Constant<T, L> {
     type Msg = ();
     type Listener = L;
 
-    fn listen<L2: crate::IntoDynListener<Self::Msg, Self::Listener>>(&self, _: L2) {
+    fn listen<L2: IntoListener<L, ()>>(&self, _: L2) {
         // do nothing, skipping the boxing that would happen if we only implemented listen_raw()
     }
     fn listen_raw(&self, _: Self::Listener) {}

--- a/src/source/map.rs
+++ b/src/source/map.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::{Listen, Source};
+use crate::{IntoListener, Listen, Source};
 
 /// A [`Source`] whose values are produced by applying a function to another source.
 ///
@@ -21,10 +21,7 @@ impl<S: Source, F> Listen for Map<S, F> {
         self.source.listen_raw(listener)
     }
 
-    fn listen<L: crate::IntoDynListener<Self::Msg, Self::Listener>>(&self, listener: L)
-    where
-        Self: Sized,
-    {
+    fn listen<L: IntoListener<Self::Listener, Self::Msg>>(&self, listener: L) {
         self.source.listen(listener)
     }
 }

--- a/tests/api/any_flavor/notifier.rs
+++ b/tests/api/any_flavor/notifier.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use super::flavor::{Notifier, RawNotifier};
 use nosy::sync::DynListener;
-use nosy::{IntoDynListener, Listen as _, Listener, Log};
+use nosy::{FromListener, Listen as _, Listener, Log};
 
 #[test]
 fn basics_and_debug() {
@@ -133,7 +133,9 @@ fn drops_listeners_even_with_no_messages(listen: &mut dyn FnMut(DynListener<()>)
     }
 
     for _ in 0..100 {
-        listen(MomentaryListener::new(counters.clone()).into_dyn_listener());
+        listen(DynListener::from_listener(MomentaryListener::new(
+            counters.clone(),
+        )));
     }
 
     // The exact number here will depend on the details of `Notifier` and `Vec`;

--- a/tests/api/any_flavor/store.rs
+++ b/tests/api/any_flavor/store.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 use super::flavor;
-use nosy::{IntoDynListener, Listener as _, StoreLock};
+use nosy::{FromListener, Listener as _, StoreLock};
 
 #[test]
 fn store_lock_debug() {
@@ -26,7 +26,7 @@ fn store_lock_listener_debug() {
 
 #[test]
 fn store_lock_meets_trait_bounds() {
-    let _: flavor::DynListener<i32> = StoreLock::new(vec![]).listener().into_dyn_listener();
+    let _ = flavor::DynListener::<i32>::from_listener(StoreLock::new(vec![]).listener());
 }
 
 #[test]


### PR DESCRIPTION
This breaking change fixes #23.

This rearrangement of generic parameters allows `FromListener<L, M>` to be implemented generically for a specific type outside the `nosy` crate, such as an `enum` of listener types:

```rust
enum Listener {
    Flag(nosy::FlagListener),
    ...
}
impl<M> nosy::FromListener<nosy::FlagListener, M> for Listener {
```

Previously, this would be a coherence error because `M` would have been an “uncovered” type parameter occurring before `Listener`. The new `Self` and parameter ordering makes it possible to do this because the local type `Listener` appears first. By putting the destination type first, we also

In exchange, we are losing the ability to write implementations of the form

```rust
impl<L> nosy::IntoDynListener<LocalMsg, L> for nosy::Flag {...}
```

but that implementation does not make sense unless the purpose of the implementation is to implicitly adapt the message type `LocalMsg` to another — which is not the purpose of implementing `IntoDynListener`. I am confident that `M` should be last because it is the most likely to remain generic except when the `Self` type is local.

The swap of `Self` and `L`, source and destination types, enables blanket implementing `FromListener` for some destination type, such as a new kind of type-erased smart pointer:

```rust
impl<L, M> nosy::FromListener<L, M> for LocalListener {...}
```

In exchange, we lose the ability to implement conversion *from* a local type to a generic one,

```rust
impl<L> nosy::FromListener<LocalListener, ()> for L {...}
```

which could in principle be used for making a concrete listener fit into more kinds of erased listener types (via an intermediate conversion step). But I don’t think that’s more worthwhile.

In order to avoid regressing the convenience of accepting listeners, the new sealed trait `IntoListener<L, M>` is blanket implemented and serves the role of the old `IntoDynListener` trait. (That does not make this not a breaking change, because the parameter order has changed and `IntoListener` cannot be implemented.)
