### PR TITLE
Add more `fmt::Pointer` implementations.

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -56,6 +56,13 @@ impl<F, T: fmt::Debug, const BATCH: usize> fmt::Debug for Filter<F, T, BATCH> {
     }
 }
 
+impl<F, T: fmt::Pointer, const BATCH: usize> fmt::Pointer for Filter<F, T, BATCH> {
+    /// Produces the same output as the listener this filter wraps.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.target, f)
+    }
+}
+
 impl<MI, MO, F, T, const BATCH: usize> Listener<MI> for Filter<F, T, BATCH>
 where
     F: Fn(&MI) -> Option<MO> + Send + Sync,

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -571,6 +571,13 @@ impl<M, L> fmt::Debug for NotifierForwarder<M, L> {
     }
 }
 
+impl<M, L> fmt::Pointer for NotifierForwarder<M, L> {
+    /// Produces the address of the `Notifier` this forwards to.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.as_ptr().fmt(f)
+    }
+}
+
 impl<M, L: Listener<M>> Listener<M> for NotifierForwarder<M, L> {
     fn receive(&self, messages: &[M]) -> bool {
         if let Some(notifier) = self.0.upgrade() {

--- a/src/simple_listeners.rs
+++ b/src/simple_listeners.rs
@@ -102,6 +102,19 @@ impl<M> fmt::Debug for LogListener<M> {
     }
 }
 
+impl<M> fmt::Pointer for Log<M> {
+    /// Produces an address which is the same for this [`Log`] and its associated [`LogListener`]s.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        StoreLock::fmt(&self.0, f)
+    }
+}
+impl<M> fmt::Pointer for LogListener<M> {
+    /// Produces an address which is the same for this [`LogListener`] and its associated [`Log`].
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        StoreLockListener::fmt(&self.0, f)
+    }
+}
+
 impl<M: Clone + Send + Sync> Listener<M> for LogListener<M> {
     fn receive(&self, messages: &[M]) -> bool {
         self.0.receive(messages)
@@ -170,6 +183,20 @@ impl fmt::Debug for FlagListener {
             ds.field("value", &(strong.load(Ordering::Relaxed)));
         }
         ds.finish()
+    }
+}
+
+impl fmt::Pointer for Flag {
+    /// Produces an address which is the same for this [`Flag`] and its associated
+    /// [`FlagListener`]s.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Arc::as_ptr(&self.shared).fmt(f)
+    }
+}
+impl fmt::Pointer for FlagListener {
+    /// Produces an address which is the same for this [`FlagListener`] and its associated [`Flag`].
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.weak.as_ptr().fmt(f)
     }
 }
 

--- a/src/source/flatten.rs
+++ b/src/source/flatten.rs
@@ -1,5 +1,6 @@
 use alloc::sync::Arc;
 use alloc::sync::Weak;
+use core::fmt;
 use core::sync::atomic::AtomicU32;
 use core::sync::atomic::Ordering;
 
@@ -191,5 +192,16 @@ pub struct InnerListener<S: Source<Value: Source>>(
 impl<S: Source<Value: Source>> Listener<()> for InnerListener<S> {
     fn receive(&self, messages: &[()]) -> bool {
         self.0.receive(messages)
+    }
+}
+
+impl<S: Source<Value: Source>> fmt::Pointer for OuterListener<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.shared.as_ptr().fmt(f)
+    }
+}
+impl<S: Source<Value: Source>> fmt::Pointer for InnerListener<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -145,6 +145,21 @@ impl<T: ?Sized> fmt::Debug for StoreLockListener<T> {
     }
 }
 
+impl<T: ?Sized> fmt::Pointer for StoreLock<T> {
+    /// Produces an address which is the same for this [`StoreLock`] and its associated
+    /// [`StoreLockListener`]s.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        MaRc::as_ptr(&self.0).fmt(f)
+    }
+}
+impl<T: ?Sized> fmt::Pointer for StoreLockListener<T> {
+    /// Produces an address which is the same for this [`StoreLockListener`] and its associated
+    /// [`StoreLock`].
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.as_ptr().fmt(f)
+    }
+}
+
 impl<T> StoreLock<T> {
     /// Construct a new [`StoreLock`] with the given initial state.
     pub fn new(initial_state: T) -> Self {

--- a/tests/api/any_flavor/cell.rs
+++ b/tests/api/any_flavor/cell.rs
@@ -37,6 +37,17 @@ fn cell_and_source_debug() {
 }
 
 #[test]
+fn pointer_fmt_eq() {
+    let cell = flavor::Cell::<Vec<&'static str>>::new(vec!["hi"]);
+    let source = cell.as_source();
+    assert_eq!(
+        format!("{cell:p}"),
+        format!("Cell {{ cell_address: {source:p} }}"),
+        "pointer formatting not matching as expected"
+    )
+}
+
+#[test]
 fn cell_usage() {
     let cell = flavor::Cell::<i32>::new(0i32);
 

--- a/tests/api/any_flavor/filter.rs
+++ b/tests/api/any_flavor/filter.rs
@@ -1,5 +1,5 @@
 use super::flavor::Notifier;
-use nosy::{Listen as _, Listener as _, NullListener, Log};
+use nosy::{Listen as _, Listener as _, Log, NullListener};
 
 use crate::tools::CaptureBatch;
 
@@ -8,14 +8,24 @@ fn filter_debug() {
     fn foo(x: &i32) -> Option<i32> {
         Some(x + 1)
     }
-    
+
     let listener = NullListener.filter(foo);
-    
+
     let fn_name = std::any::type_name_of_val(&foo);
     assert_eq!(
         format!("{listener:?}"),
         format!("Filter {{ function: {fn_name}, target: NullListener }}")
     );
+}
+
+#[test]
+fn filter_pointer_fmt_eq() {
+    let listener = Log::<()>::new().listener();
+    assert_eq!(
+        format!("{listener:p}"),
+        format!("{:p}", listener.filter(|&x| Some(x))),
+        "pointer formatting not equal as expected"
+    )
 }
 
 #[test]

--- a/tests/api/any_flavor/gate.rs
+++ b/tests/api/any_flavor/gate.rs
@@ -22,3 +22,16 @@ fn gate() {
 
     assert_eq!(notifier.count(), 0);
 }
+
+#[test]
+fn pointer_fmt_eq() {
+    let log = Log::new();
+    let original_listener = log.listener();
+    let (gate, gate_listener): (nosy::Gate, nosy::GateListener<nosy::LogListener<i32>>) =
+        original_listener.clone().gate();
+    assert_eq!(
+        format!("GateListener {{ gate: {gate:p}, target: {original_listener:p} }}"),
+        format!("{gate_listener:p}"),
+        "pointer formatting not equal as expected"
+    )
+}

--- a/tests/api/any_flavor/notifier.rs
+++ b/tests/api/any_flavor/notifier.rs
@@ -58,6 +58,17 @@ fn forwarder_debug() {
 }
 
 #[test]
+fn forwarder_pointer_fmt_eq() {
+    let n: Arc<Notifier<u8>> = Arc::new(Notifier::new());
+    let nf = Notifier::forwarder(Arc::downgrade(&n));
+    assert_eq!(
+        format!("{n:p}"),
+        format!("{nf:p}"),
+        "pointer formatting not equal as expected"
+    )
+}
+
+#[test]
 fn close_drops_listeners() {
     #[derive(Debug)]
     struct DropDetector(Arc<()>);

--- a/tests/api/any_flavor/simple_listeners.rs
+++ b/tests/api/any_flavor/simple_listeners.rs
@@ -63,6 +63,17 @@ fn log_debug() {
 }
 
 #[test]
+fn log_pointer_fmt_eq() {
+    let log: Log<i32> = Log::new();
+    let listener = log.listener();
+    assert_eq!(
+        format!("{log:p}"),
+        format!("{listener:p}"),
+        "pointer formatting not equal as expected"
+    )
+}
+
+#[test]
 fn flag_alive() {
     let notifier: Notifier<()> = Notifier::new();
     let flag = Flag::new(false);
@@ -104,4 +115,15 @@ fn flag_debug() {
     );
     drop(flag);
     assert_eq!(format!("{listener:?}"), "FlagListener { alive: false }");
+}
+
+#[test]
+fn flag_pointer_fmt_eq() {
+    let flag = Flag::new(false);
+    let listener = flag.listener();
+    assert_eq!(
+        format!("{flag:p}"),
+        format!("{listener:p}"),
+        "pointer formatting not equal as expected"
+    )
 }

--- a/tests/api/any_flavor/store.rs
+++ b/tests/api/any_flavor/store.rs
@@ -25,6 +25,17 @@ fn store_lock_listener_debug() {
 }
 
 #[test]
+fn pointer_fmt_eq() {
+    let sl: StoreLock<Vec<&'static str>> = StoreLock::new(vec!["initial"]);
+    let listener = sl.listener();
+    assert_eq!(
+        format!("{sl:p}"),
+        format!("{listener:p}"),
+        "pointer formatting not equal as expected"
+    )
+}
+
+#[test]
 fn store_lock_meets_trait_bounds() {
     let _ = flavor::DynListener::<i32>::from_listener(StoreLock::new(vec![]).listener());
 }

--- a/tests/api/future.rs
+++ b/tests/api/future.rs
@@ -104,3 +104,34 @@ fn wake_flag_stream() {
         vec!["sending", "sent", "received", "sending", "sent", "received"]
     );
 }
+
+#[test]
+fn wake_flag_debug() {
+    let (mut flag, listener) = nosy::future::WakeFlag::new(false);
+    assert_eq!(
+        format!("{flag:?} {listener:?}"),
+        "WakeFlag(false) WakeFlagListener { alive: true, value: false }"
+    );
+    listener.receive(&[123]);
+    assert_eq!(
+        format!("{flag:?} {listener:?}"),
+        "WakeFlag(true) WakeFlagListener { alive: true, value: true }"
+    );
+    futures::executor::block_on(flag.wait());
+    assert_eq!(
+        format!("{flag:?} {listener:?}"),
+        "WakeFlag(false) WakeFlagListener { alive: true, value: false }"
+    );
+    drop(flag);
+    assert_eq!(format!("{listener:?}"), "WakeFlagListener { alive: false }");
+}
+
+#[test]
+fn wake_flag_pointer_fmt_eq() {
+    let (flag, listener) = nosy::future::WakeFlag::new(false);
+    assert_eq!(
+        format!("{flag:p}"),
+        format!("{listener:p}"),
+        "pointer formatting not equal as expected"
+    )
+}


### PR DESCRIPTION
Unlike the existing implementations for `Cell` and `CellWithLocal`, these do not include the type of the listener. I’m not sure which way is better, but not doing so makes `Log`’s implementation possible in a compositional way, without needing a `StoreLock::as_ptr()` method to get the un-labeled address, which seems like a good sign to me.

All implementations are tested except for `Flatten`’s listeners.