### PR TITLE
Add reflexive `FromListener` impls to all `Listener`s.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -3,25 +3,41 @@
 use crate::{sync, unsync, Listener};
 
 #[cfg(doc)]
-use crate::Listen;
+use crate::{Listen, Notifier};
 
 // -------------------------------------------------------------------------------------------------
 // Traits
 
 #[cfg_attr(not(feature = "async"), allow(rustdoc::broken_intra_doc_links))]
-/// Conversion from a concrete listener type to (normally) some flavor of boxed trait object.
+/// Conversion from a specific listener type to a more general listener type,
+/// such as a trait object.
 ///
 /// This trait is typically used via calling [`Listen::listen()`], or an [`IntoListener`] bound
-/// on a function’s parameter.
-/// It generally does not need to be implemented,
-/// unless you are using a custom type for your type-erased listeners that is neither
-/// [`sync::DynListener`] nor [`unsync::DynListener`].
+/// on a function’s parameter, to convert listeners of the provided type into a more common type
+/// that can be stored in a [`Notifier`]’s listener set.
 ///
 /// # Generic parameters
 ///
 /// * `Self` is the listener type being converted to.
 /// * `L` is the listener type being converted from.
 /// * `M` is the type of message accepted by the listener.
+///
+/// # When to implement `FromListener`
+///
+/// There are two kinds of implementations of `FromListener`:
+///
+/// * Conversion to trait objects, like [`sync::DynListener`] and [`unsync::DynListener`], or enums.
+///   You would write such an implementation if you are using a custom type for your type-erased
+///   listeners (e.g. to add more required traits to allow more inspection of the listeners).
+///
+/// * Reflexive implementations, allowing the use of a [`Notifier`] that accepts only one type of
+///   listener and does no dynamic dispatch.
+///   You may write such an implementation, `impl FromListener<MyListener, MyMsg> for MyListener`,
+///   whenever you implement `Listener`.
+///
+///   Unfortunately, we cannot provide a blanket implementation of this type,
+///   `impl<L: Listener<M>, M> FromListener<L, M> for L`,
+///   because it would conflict with the other kind of implementation.
 ///
 /// # Example implementation
 ///

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -105,3 +105,15 @@ where
         }
     }
 }
+
+impl<MI, MO, F, T: Listener<MO>, const BATCH: usize> crate::FromListener<Filter<F, T, BATCH>, MI>
+    for Filter<F, T, BATCH>
+where
+    F: Fn(&MI) -> Option<MO> + Send + Sync,
+    T: Listener<MO>,
+{
+    /// No-op conversion returning the listener unchanged.
+    fn from_listener(listener: Filter<F, T, BATCH>) -> Self {
+        listener
+    }
+}

--- a/src/future.rs
+++ b/src/future.rs
@@ -217,6 +217,13 @@ impl<M> Listener<M> for WakeFlagListener {
     }
 }
 
+impl<M> crate::FromListener<WakeFlagListener, M> for WakeFlagListener {
+    /// No-op conversion returning the listener unchanged.
+    fn from_listener(listener: WakeFlagListener) -> Self {
+        listener
+    }
+}
+
 impl Drop for WakeFlagListener {
     fn drop(&mut self) {
         if let Some(shared) = self.shared.upgrade() {

--- a/src/gate.rs
+++ b/src/gate.rs
@@ -64,6 +64,13 @@ where
     }
 }
 
+impl<L: Listener<M>, M> crate::FromListener<GateListener<L>, M> for GateListener<L> {
+    /// No-op conversion returning the listener unchanged.
+    fn from_listener(listener: GateListener<L>) -> Self {
+        listener
+    }
+}
+
 impl fmt::Pointer for Gate {
     /// Produces an address which identifies this [`Gate`] and its associated [`GateListener`]s.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/store.rs
+++ b/src/store.rs
@@ -254,6 +254,15 @@ impl<M, T: ?Sized + Store<M> + Send> Listener<M> for StoreLockListener<T> {
     }
 }
 
+impl<T: ?Sized + Store<M> + Send, M> crate::FromListener<StoreLockListener<T>, M>
+    for StoreLockListener<T>
+{
+    /// No-op conversion returning the listener unchanged.
+    fn from_listener(listener: StoreLockListener<T>) -> Self {
+        listener
+    }
+}
+
 fn receive_bare_mutex<M, T: ?Sized + Store<M>>(
     mutex: &maybe_sync::Mutex<T>,
     messages: &[M],


### PR DESCRIPTION
This allows the creation of `Notifier`s that accept only a single concrete listener type.

---

An alternative to this change would be to make a single generic struct that has the reflexive impl:

```rust
struct Only<L>(pub L);
impl<L: Listener<M>, M> FromListener<L, M> for Only<L> {...}
impl<L: Listener<M>, M> FromListener<Only<L>, M> for Only<L> {...}
```

This would be more general, but less ergonomic to use. We could provide both, but I currently think “more impls, that you can use if you need” is more value per cost than “more special-purpose public items”.