### PR TITLE
Change Rust edition from 2021 to 2024.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly, 1.83.0]
+        toolchain: [stable, beta, nightly, 1.85.0]
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.toolchain != 'stable' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0 (Unreleased)
+
+### Changed
+
+- The minimum supported Rust version is now 1.85.
+
 ## 0.1.1 (2025-06-12)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 ## 0.2.0 (Unreleased)
 
+### Added
+
+- New trait implementations allow creating a `Notifier` for a single listener type only, like `nosy::Listener<nosy::Flag, ()>`. Such notifiers can be more efficient by avoiding dynamic dispatch and indirection.
+- All provided listener and destination types now implement `fmt::Pointer`.
+  This can be used like `eprintln!("{listener:p}")` to identify which shared state a listener is updating.
+
 ### Changed
 
 - The minimum supported Rust version is now 1.85.
+- The trait `IntoDynListener` has been split into two traits, `FromListener`, and `IntoListener`.
+  `FromListener` newly allows blanket implementations for converting to types not defined in `nosy` itself, i.e. `impl<L, M> FromListener<L, M> for MyPointer<dyn MyListener>`.
+  `IntoListener` is a sealed trait implemented for all `FromListener`, which is more convenient to use when accepting a listener than `FromListener` is.
 
 ## 0.1.1 (2025-06-12)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = ["xtask"]
 [package]
 name = "nosy"
 version = "0.2.0"
-edition = "2021"
-rust-version = "1.83.0"
+edition = "2024"
+rust-version = "1.85.0"
 description = "Change notification / observation / broadcast channels, with filtering and coalescing. no_std compatible."
 repository = "https://github.com/kpreid/nosy/"
 license = "MIT OR Apache-2.0"

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,6 +1,6 @@
 //! Type-erasure related traits and impls.
 
-use crate::{sync, unsync, Listener};
+use crate::{Listener, sync, unsync};
 
 #[cfg(doc)]
 use crate::{Listen, Notifier};

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -11,7 +11,7 @@ use crate::maybe_sync::RwLock;
 use crate::{IntoListener, Listen, Listener};
 
 #[cfg(doc)]
-use crate::{sync, FromListener, Source};
+use crate::{FromListener, Source, sync};
 
 // -------------------------------------------------------------------------------------------------
 

--- a/src/source/flatten.rs
+++ b/src/source/flatten.rs
@@ -5,8 +5,8 @@ use core::sync::atomic::AtomicU32;
 use core::sync::atomic::Ordering;
 
 use crate::{
-    maybe_sync, FromListener, Gate, GateListener, IntoListener, Listen, Listener, Notifier,
-    NotifierForwarder, Source,
+    FromListener, Gate, GateListener, IntoListener, Listen, Listener, Notifier, NotifierForwarder,
+    Source, maybe_sync,
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
-use crate::maybe_sync::{self, MaRc, MaWeak};
 use crate::Listener;
+use crate::maybe_sync::{self, MaRc, MaWeak};
 
 /// A data structure which records received messages for later processing.
 ///

--- a/tests/api/listener.rs
+++ b/tests/api/listener.rs
@@ -4,7 +4,7 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use nosy::{sync, unsync, Flag, FromListener, Listen, Log, NullListener};
+use nosy::{Flag, FromListener, Listen, Log, NullListener, sync, unsync};
 
 #[test]
 fn dyn_listen_is_possible() {


### PR DESCRIPTION
All edition migration changes in this commit are formatting only. The motivation for this change is to get access to combined doctests to keep testing fast even as I add more doctests.