### PR TITLE
Add `trait LoadStore` to allow plugging a new mutex (or atomic type) into `Cell`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+## Added
+
+- `trait LoadStore`, which can be used to provide alternative interior mutability (such as a `no_std` `Mutex` type) to `nosy::Cell`.
+  Provided implementations also allow using `Cell` or `Atomic*` rather than a `Mutex` or `RefCell`, to increase efficiency.
+
+## Changed
+
+- The first generic parameter of `nosy::Cell` is now the type of the interior mutable container for the value rather than the value.
+  (The type aliases `nosy::{sync,unsync}::Cell` have not changed.)
+
 ## 0.2.0 (2025-08-24)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["xtask"]
 
 [package]
 name = "nosy"
-version = "0.2.0"
+version = "0.3.0-alpha"
 edition = "2024"
 rust-version = "1.85.0"
 description = "Change notification / observation / broadcast channels, with filtering and coalescing. no_std compatible."

--- a/src/load_store.rs
+++ b/src/load_store.rs
@@ -1,0 +1,257 @@
+use core::mem;
+use core::sync::atomic::{self, Ordering::Relaxed};
+
+// -------------------------------------------------------------------------------------------------
+
+#[cfg_attr(not(feature = "sync"), allow(rustdoc::broken_intra_doc_links))]
+/// Interior-mutable storage for a value that can be replaced or copied.
+///
+/// Types implementing this trait can be used to provide interior mutability for
+/// [`nosy::Cell`][crate::Cell].
+///
+/// This trait is implemented for
+/// [`core::cell::Cell`],
+/// [`std::sync::Mutex`] when the `"sync"` or `"std"` features are enabled,
+/// and all [atomic types][core::sync::atomic].
+/// You can implement it in order to make use of a `Mutex` type other than the one from [`std`].
+///
+pub trait LoadStore {
+    /// The type of value this container stores.
+    ///
+    /// For example, `<Mutex<T> as LoadStore>::Value = T`.
+    type Value;
+
+    /// Creates a new interior-mutable container whose initial value is `value`.
+    fn new(value: Self::Value) -> Self
+    where
+        Self: Sized;
+
+    /// Returns a clone of the value currently in this interior-mutable container.
+    ///
+    /// # Panics
+    ///
+    /// Implementations may panic or hang (deadlock) if called within [`Self::Value`]’s
+    /// [`Clone`] or [`PartialEq`] operations, thus potentially causing reentrancy from within
+    /// [`Self::replace()`] or [`Self::replace_if_unequal()`].
+    fn get(&self) -> Self::Value;
+
+    /// Replaces the value currently in this interior-mutable container,
+    /// and returns the old value.
+    ///
+    /// # Panics
+    ///
+    /// Implementations may panic or hang (deadlock) if called within [`Self::Value`]’s
+    /// [`Clone`] or [`PartialEq`] operations, thus potentially causing reentrancy from within
+    /// [`Self::get()`] or [`Self::replace_if_unequal()`].
+    ///
+    // API design note: By returning the value, even if the caller doesn’t want to do anything with
+    // it, we allow the caller to control the timing of the drop of the value, and encourage
+    // implementations not to drop the value with a mutex held.
+    fn replace(&self, new_value: Self::Value) -> Self::Value;
+
+    /// Compares the current value to `new_value` and replaces it if it is unequal.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Ok(old_value)` if the value was different, or `Err(new_value)` if it was the same.
+    ///
+    /// # Panics
+    ///
+    /// Implementations may panic or hang (deadlock) if called within [`Self::Value`]’s
+    /// [`Clone`] or [`PartialEq`] operations, thus potentially causing reentrancy from within
+    /// [`Self::get()`] or [`Self::replace()`].
+    fn replace_if_unequal(&self, new_value: Self::Value) -> Result<Self::Value, Self::Value>
+    where
+        Self::Value: PartialEq;
+}
+
+// -------------------------------------------------------------------------------------------------
+// `core::cell` impls
+
+impl<T: Copy> LoadStore for core::cell::Cell<T> {
+    type Value = T;
+    fn new(value: T) -> Self {
+        core::cell::Cell::new(value)
+    }
+    fn get(&self) -> T {
+        core::cell::Cell::get(self)
+    }
+    fn replace(&self, new_value: T) -> T {
+        core::cell::Cell::replace(self, new_value)
+    }
+    fn replace_if_unequal(&self, new_value: Self::Value) -> Result<T, T>
+    where
+        Self::Value: PartialEq,
+    {
+        if new_value == core::cell::Cell::get(self) {
+            Err(new_value)
+        } else {
+            Ok(core::cell::Cell::replace(self, new_value))
+        }
+    }
+}
+
+impl<T: Clone> LoadStore for core::cell::RefCell<T> {
+    type Value = T;
+    fn new(value: T) -> Self {
+        core::cell::RefCell::new(value)
+    }
+    fn get(&self) -> T {
+        self.borrow().clone()
+    }
+    fn replace(&self, new_value: T) -> T {
+        mem::replace(&mut *self.borrow_mut(), new_value)
+    }
+    fn replace_if_unequal(&self, new_value: Self::Value) -> Result<T, T>
+    where
+        Self::Value: PartialEq,
+    {
+        let mut guard: core::cell::RefMut<'_, T> = self.borrow_mut();
+        if new_value == *guard {
+            Err(new_value)
+        } else {
+            Ok(mem::replace(&mut *guard, new_value))
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// `std::sync` impls
+
+#[cfg(any(feature = "sync", feature = "std"))]
+impl<T: Clone> LoadStore for std::sync::Mutex<T> {
+    type Value = T;
+    fn new(value: T) -> Self {
+        std::sync::Mutex::new(value)
+    }
+    fn get(&self) -> T {
+        unpoison(self.lock()).clone()
+    }
+    fn replace(&self, new_value: T) -> T {
+        mem::replace(&mut *unpoison(self.lock()), new_value)
+    }
+    fn replace_if_unequal(&self, new_value: Self::Value) -> Result<T, T>
+    where
+        Self::Value: PartialEq,
+    {
+        let mut guard: std::sync::MutexGuard<'_, T> = unpoison(self.lock());
+        if new_value == *guard {
+            Err(new_value)
+        } else {
+            Ok(mem::replace(&mut *guard, new_value))
+        }
+    }
+}
+
+#[cfg(any(feature = "sync", feature = "std"))]
+impl<T: Clone> LoadStore for std::sync::RwLock<T> {
+    type Value = T;
+    fn new(value: T) -> Self {
+        std::sync::RwLock::new(value)
+    }
+    fn get(&self) -> T {
+        unpoison(self.read()).clone()
+    }
+    fn replace(&self, new_value: T) -> T {
+        mem::replace(&mut *unpoison(self.write()), new_value)
+    }
+    fn replace_if_unequal(&self, new_value: Self::Value) -> Result<T, T>
+    where
+        Self::Value: PartialEq,
+    {
+        let mut guard: std::sync::RwLockWriteGuard<'_, T> = unpoison(self.write());
+        if new_value == *guard {
+            Err(new_value)
+        } else {
+            Ok(mem::replace(&mut *guard, new_value))
+        }
+    }
+}
+
+/// Lock poisoning can be ignored, because the only way we ever modify the value in the mutex
+/// is by [`mem::replace`] which does not panic, so the value is, at worst, stale, not
+/// internally inconsistent.
+#[cfg(any(feature = "sync", feature = "std"))]
+fn unpoison<T>(result: Result<T, std::sync::PoisonError<T>>) -> T {
+    match result {
+        Ok(guard) => guard,
+        Err(error) => error.into_inner(),
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// `core::sync::atomic` impls
+
+macro_rules! impl_load_store_for_atomic {
+    ($width:literal, $base_type:ident, $atomic_type:ident) => {
+        #[cfg(target_has_atomic = $width)]
+        impl LoadStore for atomic::$atomic_type {
+            type Value = $base_type;
+
+            fn new(value: Self::Value) -> Self {
+                Self::new(value)
+            }
+
+            fn get(&self) -> Self::Value {
+                Self::load(self, Relaxed)
+            }
+
+            fn replace(&self, new_value: Self::Value) -> Self::Value {
+                Self::swap(self, new_value, Relaxed)
+            }
+
+            fn replace_if_unequal(
+                &self,
+                new_value: Self::Value,
+            ) -> Result<Self::Value, Self::Value> {
+                let old_value = Self::swap(self, new_value, Relaxed);
+                if old_value == new_value {
+                    Err(new_value)
+                } else {
+                    Ok(old_value)
+                }
+            }
+        }
+    };
+}
+
+impl_load_store_for_atomic!("8", bool, AtomicBool);
+impl_load_store_for_atomic!("8", u8, AtomicU8);
+impl_load_store_for_atomic!("8", i8, AtomicI8);
+impl_load_store_for_atomic!("16", u16, AtomicU16);
+impl_load_store_for_atomic!("16", i16, AtomicI16);
+impl_load_store_for_atomic!("32", u32, AtomicU32);
+impl_load_store_for_atomic!("32", i32, AtomicI32);
+impl_load_store_for_atomic!("64", u64, AtomicU64);
+impl_load_store_for_atomic!("64", i64, AtomicI64);
+// impl_for_atomic!("128", u128, AtomicU128); // unstable <https://github.com/rust-lang/rust/issues/99069>
+// impl_for_atomic!("128", i128, AtomicI128);
+impl_load_store_for_atomic!("ptr", usize, AtomicUsize);
+impl_load_store_for_atomic!("ptr", isize, AtomicIsize);
+
+impl<T> LoadStore for atomic::AtomicPtr<T> {
+    type Value = *mut T;
+
+    fn new(value: Self::Value) -> Self {
+        Self::new(value)
+    }
+
+    fn get(&self) -> Self::Value {
+        Self::load(self, Relaxed)
+    }
+
+    fn replace(&self, new_value: Self::Value) -> Self::Value {
+        Self::swap(self, new_value, Relaxed)
+    }
+
+    fn replace_if_unequal(&self, new_value: Self::Value) -> Result<Self::Value, Self::Value> {
+        let old_value = Self::swap(self, new_value, Relaxed);
+        if old_value == new_value {
+            Err(new_value)
+        } else {
+            Ok(old_value)
+        }
+    }
+}
+
+// TODO: Also implement for `lock_api` and `arc_swap` optionally

--- a/tests/api/any_flavor/source.rs
+++ b/tests/api/any_flavor/source.rs
@@ -1,11 +1,6 @@
-use std::sync::Arc;
-
 use nosy::{Listen as _, Log, Source as _};
 
 use super::flavor;
-
-// TODO: put this in the flavor modules?
-type CellSource<T> = Arc<nosy::CellSource<T, flavor::DynListener<()>>>;
 
 mod constant {
     use super::*;
@@ -38,7 +33,7 @@ mod flatten {
         let cell_2 = flavor::Cell::new(20);
         let cell_of_source = flavor::Cell::new(cell_1.as_source());
 
-        let flatten: nosy::Flatten<CellSource<CellSource<i8>>> =
+        let flatten: nosy::Flatten<flavor::CellSource<flavor::CellSource<i8>>> =
             cell_of_source.as_source().flatten();
         let log: Log<()> = Log::new();
         flatten.listen(log.listener());
@@ -94,7 +89,8 @@ mod map {
     #[test]
     fn usage() {
         let cell = flavor::Cell::new(1);
-        let mapped: nosy::Map<CellSource<u8>, _> = cell.as_source().map(|x: u8| u16::from(x) * 100);
+        let mapped: nosy::Map<flavor::CellSource<u8>, _> =
+            cell.as_source().map(|x: u8| u16::from(x) * 100);
         let log: Log<()> = Log::new();
         mapped.listen(log.listener());
 

--- a/tests/api/load_store.rs
+++ b/tests/api/load_store.rs
@@ -1,0 +1,70 @@
+use core::sync::atomic;
+use nosy::LoadStore;
+
+fn check_load_store_impl<S: LoadStore>(v1: S::Value, v2: S::Value)
+where
+    S::Value: Clone + PartialEq + core::fmt::Debug,
+{
+    let container = S::new(v1.clone());
+
+    // get()
+    assert_eq!(container.get(), v1, "get 1");
+    assert_eq!(container.get(), v1, "get 2");
+
+    // replace()
+    let should_be_v1 = container.replace(v2.clone());
+    assert_eq!(should_be_v1, v1, "replace result");
+    assert_eq!(container.get(), v2, "get after replace");
+
+    // replace_if_unequal() success on replacing v2 with v1
+    match container.replace_if_unequal(v1.clone()) {
+        Ok(should_be_v2) => assert_eq!(should_be_v2, v2),
+        unexpected @ Err(_) => {
+            panic!("replace_if_unequal returned unexpected failure {unexpected:?}")
+        }
+    }
+    assert_eq!(container.get(), v1, "get after replace_if_unequal success");
+
+    // replace_if_unequal() failure on replacing v1 with itself
+    match container.replace_if_unequal(v1.clone()) {
+        Err(should_be_v1) => assert_eq!(should_be_v1, v1),
+        unexpected @ Ok(_) => {
+            panic!("replace_if_unequal returned unexpected success {unexpected:?}")
+        }
+    }
+    assert_eq!(container.get(), v1, "get after replace_if_unequal failure");
+}
+
+macro_rules! test_load_store_impl {
+    ($name:ident, $type:ty, [$v1:expr, $v2:expr]) => {
+        #[test]
+        fn $name() {
+            check_load_store_impl::<$type>($v1, $v2);
+        }
+    };
+}
+
+test_load_store_impl!(cell, core::cell::Cell<i32>, [1, 2]);
+test_load_store_impl!(refcell, core::cell::RefCell<i32>, [1, 2]);
+
+#[cfg(feature = "std")]
+test_load_store_impl!(mutex, std::sync::Mutex<i32>, [1, 2]);
+#[cfg(feature = "std")]
+test_load_store_impl!(rwlock, std::sync::RwLock<i32>, [1, 2]);
+
+test_load_store_impl!(atomic_bool, atomic::AtomicBool, [false, true]);
+test_load_store_impl!(atomic_u8, atomic::AtomicU8, [1, 2]);
+test_load_store_impl!(atomic_i8, atomic::AtomicI8, [1, 2]);
+test_load_store_impl!(atomic_u16, atomic::AtomicU16, [1, 2]);
+test_load_store_impl!(atomic_i16, atomic::AtomicI16, [1, 2]);
+test_load_store_impl!(atomic_u32, atomic::AtomicU32, [1, 2]);
+test_load_store_impl!(atomic_i32, atomic::AtomicI32, [1, 2]);
+test_load_store_impl!(atomic_u64, atomic::AtomicU64, [1, 2]);
+test_load_store_impl!(atomic_i64, atomic::AtomicI64, [1, 2]);
+test_load_store_impl!(atomic_usize, atomic::AtomicUsize, [1, 2]);
+test_load_store_impl!(atomic_isize, atomic::AtomicIsize, [1, 2]);
+test_load_store_impl!(
+    atomic_ptr,
+    atomic::AtomicPtr<u8>,
+    [core::ptr::null_mut(), core::ptr::dangling_mut()]
+);

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "async")]
 mod future;
 mod listener;
+mod load_store;
 mod static_properties;
 mod tools;
 


### PR DESCRIPTION
Part of #42.

This is a breaking change: the first parameter of `nosy::Cell` is now the mutex or other interior mutability type, so `nosy::Cell<T, L>` must be replaced with `nosy::Cell<YourChoiceOfMutex<T>, L>`.

The type aliases `nosy::{sync,unsync}::Cell<T>` are unaffected.